### PR TITLE
Remove endian.h since it is unused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 *.bin
 *.swp
 *.rq
+*.gcno
 war_and_peace.txt
 peace_and_war.txt
 encode
 decode
 benchmark
+.DS_Store

--- a/benchmark.c
+++ b/benchmark.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <endian.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/decode.c
+++ b/decode.c
@@ -1,5 +1,4 @@
 
-#include <endian.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/encode.c
+++ b/encode.c
@@ -1,5 +1,3 @@
-
-#include <endian.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Including endian.h breaks builds on macOS (sys/types.h would have better compatibility), but since it's unused anyway might as well remove it :)