### PR TITLE
deps/obl: make GF2_8_MUL[] const

### DIFF
--- a/deps/obl/gf2_8_mul_table.h
+++ b/deps/obl/gf2_8_mul_table.h
@@ -2,7 +2,7 @@
 #define GF2_8_MUL_TABLE
 
 /* clang-format off */
-static uint8_t GF2_8_MUL[] =
+static const uint8_t GF2_8_MUL[] =
 {
   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, 
   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, 

--- a/deps/obl/oblas_lite.c
+++ b/deps/obl/oblas_lite.c
@@ -3,7 +3,7 @@
 
 static void obl_axpy_ref(u8 *a, u8 *b, u8 u, unsigned k)
 {
-    register u8 *u_row = &GF2_8_MUL[u << 8];
+    register const u8 *u_row = &GF2_8_MUL[u << 8];
     register u8 *ap = a, *ae = &a[k], *bp = b;
     for (; ap != ae; ap++, bp++)
         *ap ^= u_row[*bp];
@@ -11,7 +11,7 @@ static void obl_axpy_ref(u8 *a, u8 *b, u8 u, unsigned k)
 
 static void obl_scal_ref(u8 *a, u8 *b, u8 u, unsigned k)
 {
-    register u8 *u_row = &GF2_8_MUL[u << 8];
+    register const u8 *u_row = &GF2_8_MUL[u << 8];
     register u8 *ap = a, *ae = &a[k];
     for (; ap != ae; ap++)
         *ap = u_row[*ap];


### PR DESCRIPTION
This large look-up table is read-only, so make it `const`. 

This means it can be placed in ROM instead of RAM.

##### before

```
   text	   data	    bss	    dec	    hex	
  30791	  66096	  47796	 144683	  2352b
```

#### after

```
   text	   data	    bss	    dec	    hex	
  96327	    560	  47796	 144683	  2352b
```